### PR TITLE
Un-split python syllabus.

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,6 +248,10 @@ eventbrite: 18074815259
       <li>Reading and plotting data</li>
       <li>Creating and using functions</li>
       <li>Loops and conditionals</li>
+      <li>Defensive programming</li>
+      <li>Testing</li>
+      <li>Using Python from the command line</li>
+      <li>Solving problems with Python (Capstone)</li>
       <li><a href="{{site.swc_lessons}}/ref/03-python.html">Reference...</a></li>
     </ul>
   </div>
@@ -266,16 +270,6 @@ eventbrite: 18074815259
       <li>Open licenses</li>
       <li>Where to host work, and why</li>
       <li><a href="{{site.swc_lessons}}/ref/02-git.html">Reference...</a></li>
-    </ul>
-  </div>
-  <div class="col-md-6">
-    <h3>More Python and Capstone Project</h3>
-    <ul>
-      <li>Defensive programming</li>
-      <li>Testing</li>
-      <li>Using Python from the command line</li>
-      <li>Solving problems with Python (Capstone)</li>
-      <li><a href="{{site.swc_lessons}}/ref/03-python.html">Reference...</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Since the schedule already divides the python material, I thought the syllabus could just list it all outright.  Not quite as pretty, but easier to read.

What do you think @iglpdc, @petebachant?
