### PR TITLE
Link lesson sites to syllabus headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -241,7 +241,9 @@ eventbrite: 18074815259
     </ul>
   </div>
   <div class="col-md-6">
-    <h3>Programming in Python</h3>
+    <h3><a href="http://swcarpentry.github.io/python-novice-inflammation/">
+    Programming in Python
+    </a></h3>
     <ul>
       <li>Using libraries</li>
       <li>Working with arrays</li>


### PR DESCRIPTION
Hey @iglpdc, would you like to add links for the shell/git lessons?  I wasn't sure if you were going to use the canonical materials, or if you might want to link something customized...?
